### PR TITLE
replace generic Bundle-SymbolicName to avoid clashes with other plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-ClassPath>.</Bundle-ClassPath>
-                        <Bundle-SymbolicName>protege;singleton:=true</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
                         <Bundle-Category>protege</Bundle-Category>
                         <Bundle-Vendor>david bold</Bundle-Vendor>
                         <Bundle-DocURL>http://vowl.visualdataweb.org/v1</Bundle-DocURL>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-ClassPath>.</Bundle-ClassPath>
-                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.protege;singleton:=true</Bundle-SymbolicName>
                         <Bundle-Category>protege</Bundle-Category>
                         <Bundle-Vendor>david bold</Bundle-Vendor>
                         <Bundle-DocURL>http://vowl.visualdataweb.org/v1</Bundle-DocURL>


### PR DESCRIPTION
I replaced the Bundle-SymbolicName identifier "protege" with "org.visualweb.vowl". Otherwise, this plugin would clash with any other plugins using the same generic name "protege" (only one of them will load). This happened for me with the [DL-Learner](https://github.com/SmartDataAnalytics/DL-Learner-Protege-Plugin) plugin.